### PR TITLE
Update land use definitions and equations

### DIFF
--- a/pixelCalculations.ts
+++ b/pixelCalculations.ts
@@ -21,6 +21,14 @@ export const sumNumberOfTrees = (pixel: Pixel) => {
   );
 };
 
+export const isPrivateLandUse = (land_use: string) => {
+  return land_use.toLowerCase() === 'private';
+};
+
+export const isForestLandUse = (land_use: string) => {
+  return land_use.toLowerCase() === 'USDA Forest Service';
+};
+
 export const sumBiomass = (pixel: Pixel) => {
   return (
     pixel.bmfol_2 +
@@ -63,11 +71,11 @@ export const getPixelSum = (pixels: Pixel[]) => {
     cluster_no: pixels[0].cluster_no,
     county_name: pixels[0].county_name,
     land_use: pixels[0].land_use,
-    site_class: mode(pixels.map(p => p.site_class)),
-    forest_type: mode(pixels.map(p => p.forest_type)),
-    haz_class: mode(pixels.map(p => p.haz_class))
+    site_class: mode(pixels.map((p) => p.site_class)),
+    forest_type: mode(pixels.map((p) => p.forest_type)),
+    haz_class: mode(pixels.map((p) => p.haz_class)),
   };
-  pixels.map(p => (pixelSum = sumPixel(pixelSum, p)));
+  pixels.map((p) => (pixelSum = sumPixel(pixelSum, p)));
 
   return pixelSum;
 };
@@ -146,7 +154,7 @@ export const sumPixel = (pixelSummation: PixelVariables, p: Pixel) => {
     ba_15: pixelSummation.ba_15 + p.ba_15,
     ba_25: pixelSummation.ba_25 + p.ba_25,
     ba_35: pixelSummation.ba_35 + p.ba_35,
-    ba_40: pixelSummation.ba_40 + p.ba_40
+    ba_40: pixelSummation.ba_40 + p.ba_40,
   };
   return pixelSum;
 };
@@ -219,7 +227,7 @@ export const convertClusterUnits = (pixelSummation: PixelVariables, numberOfPixe
     vmsg_15: pixelSummation.vmsg_15 / numberOfPixels,
     vmsg_25: pixelSummation.vmsg_25 / numberOfPixels,
     vmsg_35: pixelSummation.vmsg_35 / numberOfPixels,
-    vmsg_40: pixelSummation.vmsg_40 / numberOfPixels
+    vmsg_40: pixelSummation.vmsg_40 / numberOfPixels,
   };
   return pixelSum;
 };

--- a/pixelCalculations.ts
+++ b/pixelCalculations.ts
@@ -26,7 +26,7 @@ export const isPrivateLandUse = (land_use: string) => {
 };
 
 export const isForestLandUse = (land_use: string) => {
-  return land_use.toLowerCase() === 'USDA Forest Service';
+  return land_use.toLowerCase() === 'USDA Forest Service'.toLowerCase();
 };
 
 export const sumBiomass = (pixel: Pixel) => {

--- a/treatments/biomassSalvage.ts
+++ b/treatments/biomassSalvage.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -19,7 +19,7 @@ export const processBiomassSalvage = (pixels: Pixel[], centerOfBiomassSum: Cente
 // Remove small trees in the following proportions:
 // 0-1" DBH - 30%, 1-5" DBH - 60%, 5-10" DBH - 90%
 const biomassSalvage = (pixel: Pixel): Pixel => {
-  const isPrivate = pixel.land_use === 'Private';
+  const isPrivate = isPrivateLandUse(pixel.land_use);
   const c2 = isPrivate ? 0.6 : 0.85;
   const c7 = 0.9;
   let treatedPixel = new PixelClass();

--- a/treatments/biomassSalvage.ts
+++ b/treatments/biomassSalvage.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isForestLandUse, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -20,7 +20,8 @@ export const processBiomassSalvage = (pixels: Pixel[], centerOfBiomassSum: Cente
 // 0-1" DBH - 30%, 1-5" DBH - 60%, 5-10" DBH - 90%
 const biomassSalvage = (pixel: Pixel): Pixel => {
   const isPrivate = isPrivateLandUse(pixel.land_use);
-  const c2 = isPrivate ? 0.6 : 0.85;
+  const isForest = isForestLandUse(pixel.land_use);
+  const c2 = isPrivate ? 0.6 : (isForest ? 0.85 : 1.0);
   const c7 = 0.9;
   let treatedPixel = new PixelClass();
 

--- a/treatments/clearcut.ts
+++ b/treatments/clearcut.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, isForestLandUse, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -9,8 +9,8 @@ export const processClearcut = (
   centerOfBiomassSum: CenterOfBiomassSum,
   treatmentName?: string
 ) => {
-  if (treatmentName === 'clearcut' && isForestLandUse(pixels[0].land_use)) {
-    throw new Error('clearcut cannot be performed on forest land');
+  if (treatmentName === 'clearcut' && !isPrivateLandUse(pixels[0].land_use)) {
+    throw new Error('clearcut can only be performed on private land');
   }
   // console.log('clearcut: processing pixels');
   const treatedPixels = pixels.map(pixel => {

--- a/treatments/clearcut.ts
+++ b/treatments/clearcut.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isForestLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -9,7 +9,7 @@ export const processClearcut = (
   centerOfBiomassSum: CenterOfBiomassSum,
   treatmentName?: string
 ) => {
-  if (treatmentName === 'clearcut' && pixels[0].land_use === 'Forest') {
+  if (treatmentName === 'clearcut' && isForestLandUse(pixels[0].land_use)) {
     throw new Error('clearcut cannot be performed on forest land');
   }
   // console.log('clearcut: processing pixels');

--- a/treatments/commercialThin.ts
+++ b/treatments/commercialThin.ts
@@ -10,8 +10,8 @@ import {
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
 export const processCommercialThin = (pixels: Pixel[], centerOfBiomassSum: CenterOfBiomassSum) => {
-  if (isForestLandUse(pixels[0].land_use)) {
-    throw new Error('commercial thin cannot be performed on forest land');
+  if (!isPrivateLandUse(pixels[0].land_use)) {
+    throw new Error('commercial thin can only be performed on private land');
   }
   // console.log('commercial thin: processing pixels');
   // console.log('calculating p values...');

--- a/treatments/commercialThin.ts
+++ b/treatments/commercialThin.ts
@@ -115,9 +115,10 @@ const commericalThinChipTreeRemoval = (
   p40: number
 ): Pixel => {
   const isPrivate = isPrivateLandUse(pixel.land_use);
+  const isForest = isForestLandUse(pixel.land_use);
   const c0 = 0.2;
-  const c2 = isPrivate ? 0.5 : 0.85;
-  const c7 = isPrivate ? 0.8 : 0.9;
+  const c2 = isPrivate ? 0.5 : (isForest ? 0.85 : 1.0);
+  const c7 = isPrivate ? 0.8 : (isForest ? 0.9 : 1.0);
 
   let treatedPixel = commercialThin(pixel, p15, p25, p35, p40);
   treatedPixel = {

--- a/treatments/groupSelection.ts
+++ b/treatments/groupSelection.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass, PixelVariablesClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { sumBiomass, sumPixel } from '../pixelCalculations';
+import { isForestLandUse, sumBiomass, sumPixel } from '../pixelCalculations';
 import { processClearcut } from './clearcut';
 import { processSelection } from './selection';
 
@@ -12,7 +12,7 @@ export const processGroupSelection = (
   centerOfBiomassSum: CenterOfBiomassSum,
   percent: number
 ): Pixel[] => {
-  if (percent === 20 && pixels[0].land_use === 'Forest') {
+  if (percent === 20 && isForestLandUse(pixels[0].land_use)) {
     throw new Error('20% group selection cannot be performed on forest land');
   }
   // console.log('group selection: processing pixels');

--- a/treatments/groupSelection.ts
+++ b/treatments/groupSelection.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass, PixelVariablesClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { isForestLandUse, sumBiomass, sumPixel } from '../pixelCalculations';
+import { isPrivateLandUse, sumBiomass, sumPixel } from '../pixelCalculations';
 import { processClearcut } from './clearcut';
 import { processSelection } from './selection';
 
@@ -12,8 +12,8 @@ export const processGroupSelection = (
   centerOfBiomassSum: CenterOfBiomassSum,
   percent: number
 ): Pixel[] => {
-  if (percent === 20 && isForestLandUse(pixels[0].land_use)) {
-    throw new Error('20% group selection cannot be performed on forest land');
+  if (percent === 20 && !isPrivateLandUse(pixels[0].land_use)) {
+    throw new Error('20% group selection can only be performed on private land');
   }
   // console.log('group selection: processing pixels');
 

--- a/treatments/selection.ts
+++ b/treatments/selection.ts
@@ -103,8 +103,9 @@ const selection = (pixel: Pixel, p: number, p_large: number): Pixel => {
 // 0-1" DBH -20%, 1-5" DBH -50%, 5-10" DBH -80%
 const selectionChipTreeRemoval = (pixel: Pixel, p: number, p_large: number): Pixel => {
   const isPrivate = isPrivateLandUse(pixel.land_use);
-  const c2 = isPrivate ? 0.5 : 0.85;
-  const c7 = isPrivate ? 0.8 : 0.9;
+  const isForest = isForestLandUse(pixel.land_use);
+  const c2 = isPrivate ? 0.5 : (isForest ? 0.85 : 1.0);
+  const c7 = isPrivate ? 0.8 : (isForest ? 0.9 : 1.0);
 
   let treatedPixel = selection(pixel, p, p_large);
   treatedPixel = {

--- a/treatments/selection.ts
+++ b/treatments/selection.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass, PixelVariables, PixelVariablesClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, getPixelSum } from '../pixelCalculations';
+import { calculateCenterOfBiomass, getPixelSum, isForestLandUse, isPrivateLandUse } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -10,7 +10,7 @@ export const processSelection = (
   centerOfBiomassSum: CenterOfBiomassSum,
   treatmentName?: string
 ) => {
-  if (treatmentName === 'selection' && pixels[0].land_use === 'Forest') {
+  if (treatmentName === 'selection' && isForestLandUse(pixels[0].land_use)) {
     throw new Error('selection cannot be performed on forest land');
   }
   const { p, p_large } = calculatePValues(pixels);
@@ -31,7 +31,7 @@ export const processSelectionChipTreeRemoval = (
   pixels: Pixel[],
   centerOfBiomassSum: CenterOfBiomassSum
 ) => {
-  if (pixels[0].land_use === 'Forest') {
+  if (isForestLandUse(pixels[0].land_use)) {
     throw new Error('selection with small tree removal cannot be performed on forest land');
   }
   const { p, p_large } = calculatePValues(pixels);
@@ -102,7 +102,7 @@ const selection = (pixel: Pixel, p: number, p_large: number): Pixel => {
 // Same as Commercial thin but with the additional removal ofsmall trees in the following proportions:
 // 0-1" DBH -20%, 1-5" DBH -50%, 5-10" DBH -80%
 const selectionChipTreeRemoval = (pixel: Pixel, p: number, p_large: number): Pixel => {
-  const isPrivate = pixel.land_use === 'Private';
+  const isPrivate = isPrivateLandUse(pixel.land_use);
   const c2 = isPrivate ? 0.5 : 0.85;
   const c7 = isPrivate ? 0.8 : 0.9;
 

--- a/treatments/selection.ts
+++ b/treatments/selection.ts
@@ -10,8 +10,8 @@ export const processSelection = (
   centerOfBiomassSum: CenterOfBiomassSum,
   treatmentName?: string
 ) => {
-  if (treatmentName === 'selection' && isForestLandUse(pixels[0].land_use)) {
-    throw new Error('selection cannot be performed on forest land');
+  if (treatmentName === 'selection' && !isPrivateLandUse(pixels[0].land_use)) {
+    throw new Error('selection can only be performed on private land');
   }
   const { p, p_large } = calculatePValues(pixels);
   // console.log('selection: processing pixels with p value: ' + p);
@@ -31,8 +31,8 @@ export const processSelectionChipTreeRemoval = (
   pixels: Pixel[],
   centerOfBiomassSum: CenterOfBiomassSum
 ) => {
-  if (isForestLandUse(pixels[0].land_use)) {
-    throw new Error('selection with small tree removal cannot be performed on forest land');
+  if (!isPrivateLandUse(pixels[0].land_use)) {
+    throw new Error('selection with small tree removal can only be performed on private land');
   }
   const { p, p_large } = calculatePValues(pixels);
   // console.log('selection chip tree removal: processing pixels with p value: ' + p);

--- a/treatments/timberSalvage.ts
+++ b/treatments/timberSalvage.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isForestLandUse, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -85,8 +85,9 @@ const timberSalvageChipTreeRemoval = (pixel: Pixel) => {
   // do basic timber salvage
   let treatedPixel = timberSalvage(pixel);
   const isPrivate = isPrivateLandUse(pixel.land_use);
-  const c0 = isPrivate ? 0.3 : 0.2;
-  const c2 = isPrivate ? 0.6 : 0.85;
+  const isForest = isForestLandUse(pixel.land_use);
+  const c0 = isPrivate ? 0.3 : (isForest ? 0.2 : 1.0);
+  const c2 = isPrivate ? 0.6 : (isForest ? 0.85 : 1.0);
   const c7 = 0.9;
   treatedPixel = {
     ...treatedPixel,

--- a/treatments/timberSalvage.ts
+++ b/treatments/timberSalvage.ts
@@ -1,6 +1,6 @@
 import { Pixel, PixelClass } from '../models/pixel';
 import { CenterOfBiomassSum } from '../models/shared';
-import { calculateCenterOfBiomass, sumBiomass } from '../pixelCalculations';
+import { calculateCenterOfBiomass, isPrivateLandUse, sumBiomass } from '../pixelCalculations';
 
 // equations from:
 // https://ucdavis.app.box.com/file/593365602124
@@ -84,7 +84,7 @@ export const processTimberSalvageChipTreeRemoval = (
 const timberSalvageChipTreeRemoval = (pixel: Pixel) => {
   // do basic timber salvage
   let treatedPixel = timberSalvage(pixel);
-  const isPrivate = pixel.land_use === 'Private';
+  const isPrivate = isPrivateLandUse(pixel.land_use);
   const c0 = isPrivate ? 0.3 : 0.2;
   const c2 = isPrivate ? 0.6 : 0.85;
   const c7 = 0.9;


### PR DESCRIPTION
We used to just have private/forest, but now we have other types.  First, we add helpers for flexible string compares against private and USDA Forest Service lands.  Then we update equations to restrict certain treatments to just private land (instead of non-forest land).

Finally, we update some equations to give different multipliers to private, forest, and other types of land.