### PR TITLE
interpolation between two processed cluster files

### DIFF
--- a/interpolate.ts
+++ b/interpolate.ts
@@ -20,7 +20,7 @@ const interpolateYears = async (
   initialYear: number,
   yearsBetween: number
 ) => {
-  console.log(`interpolating ${county} from ${initialYear} to ${initialYear + yearsBetween}`);
+  console.log(`interpolating ${county} from ${initialYear} to ${initialYear + yearsBetween + 1}`);
 
   const t0 = performance.now();
 
@@ -29,8 +29,7 @@ const interpolateYears = async (
 
   for (let i = 0; i < yearsBetween; i++) {
     const outputCsvStream = getCsvWriteStream(
-      (process.env.TREATED_OUT_DIRECTORY || './data/') +
-        `${county}_testout_${initialYear + i + 1}.csv`
+      (process.env.TREATED_OUT_DIRECTORY || './data/') + `${county}_${initialYear + i + 1}.csv`
     );
 
     outputFileStreams.push(outputCsvStream);
@@ -95,6 +94,9 @@ const interpolateYears = async (
     }
 
     // TODO: more checks? perhaps make sure year and county are the same as intended?
+    if (clusterBase.year !== initialYear || clusterFuture.year !== initialYear + yearsBetween + 1) {
+      throw new Error('years do not match');
+    }
 
     // now we need to interpolate the pixel objects
     for (let j = 0; j < yearsBetween; j++) {
@@ -157,8 +159,8 @@ const csvLineToTreatedCluster = (headers: string[], line: string): TreatedCluste
 
 const initializeAndProcess = async () => {
   await interpolateYears(
-    './data/Tehama_fake_processed_2020.csv',
-    './data/Tehama_fake_processed_2025.csv',
+    process.env.TREATED_BASE_FILE || './data/Tehama_fake_processed_2020.csv',
+    process.env.TREATED_FUTURE_FILE || './data/Tehama_fake_processed_2025.csv',
     'Tehama',
     2020,
     4

--- a/interpolate.ts
+++ b/interpolate.ts
@@ -1,0 +1,140 @@
+import dotenv from 'dotenv';
+
+import fs from 'fs';
+import { TreatedCluster } from 'models/treatedcluster';
+import { performance } from 'perf_hooks';
+import readline from 'readline';
+
+import { exportToCsv, getCsvWriteStream, processPixelsCsv } from './csvHelper';
+
+dotenv.config();
+
+// Given two files of treated clusters and a year span, generate interstertial cluster data for each year
+// Assumptions
+// we are always working with a given county and both files will represent that county N years apart
+// both files have identical row counts and columns -- they vary only in the data they contain
+const interpolateYears = async (
+  fileBase: string,
+  fileFuture: string,
+  county: string,
+  initialYear: number,
+  yearsBetween: number
+) => {
+  const t0 = performance.now();
+
+  // grab yearsBetween number of output files
+  const outputFileStreams = [];
+
+  for (let i = 0; i < yearsBetween; i++) {
+    const outputCsvStream = getCsvWriteStream(
+      (process.env.TREATED_OUT_DIRECTORY || './data/') + `${county}_${initialYear + i + 1}.csv`
+    );
+
+    outputFileStreams.push(outputCsvStream);
+  }
+
+  // grab iterators for both input files
+  const rlFileBase: any = readline.createInterface({
+    input: fs.createReadStream(fileBase),
+    crlfDelay: Infinity,
+  });
+
+  const rlFileFuture: any = readline.createInterface({
+    input: fs.createReadStream(fileFuture),
+    crlfDelay: Infinity,
+  });
+  // Note: we use the crlfDelay option to recognize all instances of CR LF
+  // ('\r\n') in input.txt as a single line break.
+
+  // get an iterator for the file
+  const itBase = rlFileBase[Symbol.asyncIterator]() as AsyncIterator<string>;
+  const itFuture = rlFileFuture[Symbol.asyncIterator]() as AsyncIterator<string>;
+
+  // first lines are headers, get them out of the way but keep track of them
+  const headerBase: string = (await itBase.next()).value;
+  const headerFuture: string = (await itFuture.next()).value;
+
+  if (headerBase !== headerFuture) {
+    throw new Error('headers do not match');
+  }
+
+  // put headers into an array for object building later
+  const headers = headerBase.replace(/['"]+/g, '').split(',');
+
+  // TODO: eventually we just run until we hit the end of the file.
+  for (let index = 0; index < 3; index++) {
+    const lineBase = await itBase.next();
+    const lineFuture = await itFuture.next();
+
+    // get our pixel objects from each line
+    const clusterBase = csvLineToTreatedCluster(headers, lineBase.value);
+    const clusterFuture = csvLineToTreatedCluster(headers, lineFuture.value);
+
+    // double check to make sure these are the same cluster
+    if (clusterBase.cluster_no !== clusterFuture.cluster_no) {
+      throw new Error('cluster numbers do not match');
+    }
+
+    // now we need to interpolate the pixel objects
+    for (let j = 0; j < yearsBetween; j++) {
+      const clusterInterpolated = await interpolateCluster(
+        clusterBase,
+        clusterFuture,
+        yearsBetween,
+        j + 1
+      );
+
+      // write the interpolated pixel to the output file
+      outputFileStreams[j].writeTreatedClusters([clusterInterpolated]);
+    }
+  }
+
+  // close all the output streams
+  outputFileStreams.forEach((o) => o.closeCsv());
+};
+
+const interpolateCluster = async (
+  clusterBase: TreatedCluster,
+  clusterFuture: TreatedCluster,
+  yearsBetween: number,
+  yearDesired: number
+) => {
+  // for each biomass type, interpolate the values between two pixels
+  // for expediency, we are going to assume biomass pixels follow _\d* format (_ follow by number)
+  const interpolatedPixel: TreatedCluster = { ...clusterBase };
+
+  for (const [key, val] of Object.entries(clusterBase)) {
+    // make sure key ends with underscore followed by a number
+    if (key.match(/_\d+$/)) {
+      // we have a biomass key, interpolate the values
+      const currentVal: number = (clusterBase as any)[key];
+      const futureVal: number = (clusterFuture as any)[key];
+
+      const interpolatedVal = (currentVal + (futureVal - currentVal) / yearsBetween) * yearDesired;
+
+      (interpolatedPixel as any)[key] = interpolatedVal;
+    }
+  }
+
+  interpolatedPixel.year += yearDesired;
+
+  return interpolatedPixel;
+};
+
+const csvLineToTreatedCluster = (headers: string[], line: string): TreatedCluster => {
+  const lineObj = line.split(',').reduce((prev: any, curr: string, idx: number) => {
+    prev[headers[idx]] = isNaN(+curr) ? curr : +curr;
+
+    return prev;
+  }, {} as any);
+
+  return lineObj as TreatedCluster;
+};
+
+const initializeAndProcess = async () => {
+  await interpolateYears('./data/Yuba_2016_fake.csv', './data/Yuba_2020_fake.csv', 'Yuba', 2016, 4);
+};
+
+initializeAndProcess()
+  .then(() => console.log('all done with processing run'))
+  .catch(console.error);

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,7 @@
   "extends": ["tslint-eslint-rules"],
   "rules": {
     "arrow-return-shorthand": true,
-    "align": [true, "arguments", "elements", "members", "parameters", "statements"],
+    "align": [false, "arguments", "elements", "members", "parameters", "statements"],
     "callable-types": true,
     "class-name": true,
     "comment-format": [true, "check-space"],


### PR DESCRIPTION
WIP -- takes two processed cluster files and the number of years between them, and linearly interpolates the interstitial years as additional output files.  Requires the two processed files to match line-by-line in order (same clusters/treatments on each line)