### PR TITLE
URL Table Sql

### DIFF
--- a/sql/db_tables.sql
+++ b/sql/db_tables.sql
@@ -149,3 +149,19 @@ create table url (
     transport_inputs varchar(10000) not null,
     short_url varchar(100) not null
 );
+
+CREATE TABLE user_details (
+    id SERIAL PRIMARY KEY,
+    full_name VARCHAR(1000) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    organization VARCHAR(1000) NOT NULL,
+    org_type VARCHAR(100) NOT NULL,
+    org_website VARCHAR(10000),
+    job_title VARCHAR(255) NOT NULL,
+    linkedin VARCHAR(1000),
+    expertise VARCHAR(100),
+    about_me TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_user_details_email ON user_details(email);

--- a/sql/db_tables.sql
+++ b/sql/db_tables.sql
@@ -143,11 +143,9 @@ insert into treatments values
 -- Create the url table
 CREATE TABLE url (
     url_id SERIAL PRIMARY KEY,
-    all_year_inputs TEXT NOT NULL,
-    biomass_coordinates TEXT NOT NULL,
-    frcs_inputs TEXT NOT NULL,
-    transport_inputs TEXT NOT NULL,
-    short_url VARCHAR(100) NOT NULL
+    data JSONB NOT NULL,
+    short_url VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Create the user_details table

--- a/sql/db_tables.sql
+++ b/sql/db_tables.sql
@@ -141,27 +141,29 @@ insert into treatments values
   
 
 -- Create the url table
-create table url (
-    url_id bigserial primary key,
-    all_year_inputs varchar(10000) not null,
-    biomass_coordinates varchar(10000) not null,
-    frcs_inputs varchar(10000) not null,
-    transport_inputs varchar(10000) not null,
-    short_url varchar(100) not null
+CREATE TABLE url (
+    url_id SERIAL PRIMARY KEY,
+    all_year_inputs TEXT NOT NULL,
+    biomass_coordinates TEXT NOT NULL,
+    frcs_inputs TEXT NOT NULL,
+    transport_inputs TEXT NOT NULL,
+    short_url VARCHAR(100) NOT NULL
 );
 
+-- Create the user_details table
 CREATE TABLE user_details (
     id SERIAL PRIMARY KEY,
-    full_name VARCHAR(1000) NOT NULL,
+    full_name VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
-    organization VARCHAR(1000) NOT NULL,
-    org_type VARCHAR(100) NOT NULL,
-    org_website VARCHAR(10000),
-    job_title VARCHAR(255) NOT NULL,
-    linkedin VARCHAR(1000),
-    expertise VARCHAR(100),
+    organization VARCHAR(100) NOT NULL,
+    org_type VARCHAR(50) NOT NULL,
+    org_website VARCHAR(255),
+    job_title VARCHAR(100) NOT NULL,
+    linkedin VARCHAR(255),
+    expertise VARCHAR(50),
     about_me TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Index on email in user_details
 CREATE INDEX idx_user_details_email ON user_details(email);

--- a/sql/db_tables.sql
+++ b/sql/db_tables.sql
@@ -141,11 +141,11 @@ insert into treatments values
   
 
 -- Create the url table
-CREATE TABLE url (
-    url_id bigserial PRIMARY KEY,
-    all_year_inputs varchar(10000) NOT NULL,
-    biomass_coordinates varchar(10000) NOT NULL,
-    frcs_inputs varchar(10000) NOT NULL,
-    transport_inputs varchar(10000) NOT NULL,
-    short_url varchar(100) NOT NULL
+create table url (
+    url_id bigserial primary key,
+    all_year_inputs varchar(10000) not null,
+    biomass_coordinates varchar(10000) not null,
+    frcs_inputs varchar(10000) not null,
+    transport_inputs varchar(10000) not null,
+    short_url varchar(100) not null
 );

--- a/sql/db_tables.sql
+++ b/sql/db_tables.sql
@@ -139,3 +139,13 @@ insert into treatments values
   (9,'twentyPercentGroupSelection','Private'),
   (10,'biomassSalvage','Private,Forest')
   
+
+-- Create the url table
+CREATE TABLE url (
+    url_id bigserial PRIMARY KEY,
+    all_year_inputs varchar(10000) NOT NULL,
+    biomass_coordinates varchar(10000) NOT NULL,
+    frcs_inputs varchar(10000) NOT NULL,
+    transport_inputs varchar(10000) NOT NULL,
+    short_url varchar(100) NOT NULL
+);


### PR DESCRIPTION
- SQL Definition and query for _url_ table required to save models in _cecdss-backend_

- This new table will store URL-related data with the following columns:
url_id: A big serial number that serves as the primary key.
all_year_inputs: A varchar field to store all year inputs (up to 10000 characters).
biomass_coordinates: A varchar field to store biomass coordinates (up to 10000 characters).
frcs_inputs: A varchar field to store FRCS inputs (up to 10000 characters).
transport_inputs: A varchar field to store transport inputs (up to 10000 characters).
short_url: A varchar field to store the short URL (up to 100 characters).